### PR TITLE
Add event batching

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -50,9 +50,8 @@ func main() {
 	server.GET("/", httpserver.GetUserEvent)
 
 	// 	 Schedule Driver
-	// genSch := schedule.New(srv, 50, srv.GenerateUserEvent)
-	batchSch := schedule.New(srv, 10, srv.BatchUserEvent)
-	drainSch := schedule.New(srv, 50, srv.PublishBatch)
+	batchSch := schedule.New(srv, 3, true, srv.BatchUserEvent)
+	drainSch := schedule.New(srv, 10, false, srv.PublishBatch)
 
 	// Run the Drivers
 	go func() {
@@ -62,7 +61,6 @@ func main() {
 		}
 	}()
 
-	// genSch.Run()
 	batchSch.Run()
 	drainSch.Run()
 

--- a/internal/core/ports/batch.go
+++ b/internal/core/ports/batch.go
@@ -3,7 +3,7 @@ package ports
 import "zd/internal/core/domain"
 
 // Port that the drivers will use to make use of the core code
-type ZendeskService interface {
-	GetUserEvent() (*domain.UserEvent, error)
-	GenerateUserEvent() error
+type Batch interface {
+	Add(*domain.UserEvent)
+	Drain() []*domain.UserEvent
 }

--- a/internal/core/ports/queue.go
+++ b/internal/core/ports/queue.go
@@ -4,4 +4,5 @@ import "zd/internal/core/domain"
 
 type UserEventQueue interface {
 	Publish(domain.UserEvent) error
+	PublishBatch([]*domain.UserEvent) error
 }

--- a/internal/driven/batch/batch.go
+++ b/internal/driven/batch/batch.go
@@ -1,0 +1,24 @@
+package batch
+
+import (
+	"zd/internal/core/domain"
+)
+
+type Batch struct {
+	data []*domain.UserEvent
+}
+
+func New() *Batch {
+	return &Batch{}
+}
+
+func (b *Batch) Add(data *domain.UserEvent) {
+	b.data = append(b.data, data)
+}
+
+func (b *Batch) Drain() []*domain.UserEvent {
+	data := b.data
+	b.data = []*domain.UserEvent{}
+
+	return data
+}

--- a/internal/driven/batch/batch_test.go
+++ b/internal/driven/batch/batch_test.go
@@ -1,0 +1,45 @@
+package batch
+
+import (
+	"testing"
+	"zd/internal/core/domain"
+)
+
+func TestBatch(t *testing.T) {
+	t.Run("Adding User Event", func(t *testing.T) {
+		batcher := New()
+
+		userEvent := domain.UserEvent{
+			UserID:  1,
+			EventID: 1,
+		}
+
+		batcher.Add(&userEvent)
+		currentBatchLength := len(batcher.data)
+		if currentBatchLength != 1 {
+			t.Errorf("expected %v, got %v", 1, currentBatchLength)
+		}
+	})
+
+	t.Run("Draining the batch", func(t *testing.T) {
+		batcher := New()
+
+		userEvent := domain.UserEvent{
+			UserID:  1,
+			EventID: 1,
+		}
+
+		batcher.Add(&userEvent)
+		currentBatchLength := len(batcher.data)
+		if currentBatchLength != 1 {
+			t.Errorf("expected %v, got %v", 1, currentBatchLength)
+		}
+
+		data := batcher.Drain()
+		returnedLength := len(data)
+
+		if returnedLength != 1 {
+			t.Errorf("got %v, expected %v", returnedLength, 1)
+		}
+	})
+}

--- a/internal/drivers/schedule/schedule.go
+++ b/internal/drivers/schedule/schedule.go
@@ -6,15 +6,19 @@ import (
 	"zd/internal/core/ports"
 )
 
+type ScheduledFunc func() error
+
 type Schedule struct {
 	zendeskService ports.ZendeskService
 	maxInterval    uint
+	fn             ScheduledFunc
 }
 
-func New(zs ports.ZendeskService, mi uint) *Schedule {
+func New(zs ports.ZendeskService, mi uint, fn ScheduledFunc) *Schedule {
 	return &Schedule{
 		zendeskService: zs,
 		maxInterval:    mi,
+		fn:             fn,
 	}
 }
 
@@ -25,7 +29,7 @@ func (s Schedule) Run() {
 			randomInterval := randomNumberGenerator.Intn(int(s.maxInterval))
 			time.Sleep(time.Second * time.Duration(randomInterval))
 
-			s.zendeskService.GetUserEvent()
+			s.fn()
 		}
 	}()
 }

--- a/internal/drivers/schedule/schedule.go
+++ b/internal/drivers/schedule/schedule.go
@@ -10,14 +10,16 @@ type ScheduledFunc func() error
 
 type Schedule struct {
 	zendeskService ports.ZendeskService
-	maxInterval    uint
+	maxInterval    int
+	random         bool
 	fn             ScheduledFunc
 }
 
-func New(zs ports.ZendeskService, mi uint, fn ScheduledFunc) *Schedule {
+func New(zs ports.ZendeskService, mi int, isRandom bool, fn ScheduledFunc) *Schedule {
 	return &Schedule{
 		zendeskService: zs,
 		maxInterval:    mi,
+		random:         isRandom,
 		fn:             fn,
 	}
 }
@@ -26,9 +28,11 @@ func (s Schedule) Run() {
 	go func() {
 		randomNumberGenerator := rand.New(rand.NewSource(time.Now().Unix()))
 		for {
-			randomInterval := randomNumberGenerator.Intn(int(s.maxInterval))
-			time.Sleep(time.Second * time.Duration(randomInterval))
-
+			wait := s.maxInterval
+			if s.random {
+				wait = randomNumberGenerator.Intn(int(s.maxInterval))
+			}
+			time.Sleep(time.Second * time.Duration(wait))
 			s.fn()
 		}
 	}()


### PR DESCRIPTION
This PR changes the data we are adding to the RabbitMQ queue. Instead of adding one event at a time, we make batching of events and add them to the queue with a preset cadence. 